### PR TITLE
Cleanup: base images

### DIFF
--- a/.github/workflows/publish-codercom.yml
+++ b/.github/workflows/publish-codercom.yml
@@ -38,7 +38,7 @@ jobs:
 
       # https://github.com/docker/login-action
       - name: Log into GitHub Container Registry
-        if: github.event_name = 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ${{ env.GHCR_REGISTRY }}
@@ -47,7 +47,7 @@ jobs:
 
       # https://github.com/docker/login-action
       - name: Log into Quay Container Registry
-        if: github.event_name = 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ${{ env.QUAY_REGISTRY }}
@@ -60,7 +60,7 @@ jobs:
           code_server_build codercom
 
       - name: kludge - push codercom
-        if: github.event_name = 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           TYPE=codercom
           docker tag custom-code-server:${TYPE}-base ${{ env.QUAY_IMAGE }}:${TYPE}-base

--- a/.github/workflows/publish-codercom.yml
+++ b/.github/workflows/publish-codercom.yml
@@ -9,6 +9,9 @@ on:
   push:
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
   
 env:
   IMAGE_NAME: code-server
@@ -35,7 +38,7 @@ jobs:
 
       # https://github.com/docker/login-action
       - name: Log into GitHub Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name = 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ${{ env.GHCR_REGISTRY }}
@@ -44,7 +47,7 @@ jobs:
 
       # https://github.com/docker/login-action
       - name: Log into Quay Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name = 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ${{ env.QUAY_REGISTRY }}
@@ -57,7 +60,7 @@ jobs:
           code_server_build codercom
 
       - name: kludge - push codercom
-        if: github.event_name != 'pull_request'
+        if: github.event_name = 'pull_request'
         run: |
           TYPE=codercom
           docker tag custom-code-server:${TYPE}-base ${{ env.QUAY_IMAGE }}:${TYPE}-base

--- a/.github/workflows/publish-ubi8.yml
+++ b/.github/workflows/publish-ubi8.yml
@@ -38,7 +38,7 @@ jobs:
 
       # https://github.com/docker/login-action
       - name: Log into GitHub Container Registry
-        #if: github.event_name != 'pull_request'
+        if: github.event_name = 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ${{ env.GHCR_REGISTRY }}
@@ -47,7 +47,7 @@ jobs:
 
       # https://github.com/docker/login-action
       - name: Log into Quay Container Registry
-        #if: github.event_name != 'pull_request'
+        if: github.event_name = 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ${{ env.QUAY_REGISTRY }}
@@ -60,7 +60,7 @@ jobs:
           code_server_build ubi8
 
       - name: kludge - push ubi8
-        #if: github.event_name != 'pull_request'
+        if: github.event_name = 'pull_request'
         run: |
           TYPE=ubi8
           docker tag custom-code-server:${TYPE}-base ${{ env.QUAY_IMAGE }}:${TYPE}-base

--- a/.github/workflows/publish-ubi8.yml
+++ b/.github/workflows/publish-ubi8.yml
@@ -38,7 +38,7 @@ jobs:
 
       # https://github.com/docker/login-action
       - name: Log into GitHub Container Registry
-        if: github.event_name = 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ${{ env.GHCR_REGISTRY }}
@@ -47,7 +47,7 @@ jobs:
 
       # https://github.com/docker/login-action
       - name: Log into Quay Container Registry
-        if: github.event_name = 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7
         with:
           registry: ${{ env.QUAY_REGISTRY }}
@@ -60,7 +60,7 @@ jobs:
           code_server_build ubi8
 
       - name: kludge - push ubi8
-        if: github.event_name = 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           TYPE=ubi8
           docker tag custom-code-server:${TYPE}-base ${{ env.QUAY_IMAGE }}:${TYPE}-base

--- a/container/base/Dockerfile.codercom
+++ b/container/base/Dockerfile.codercom
@@ -34,8 +34,12 @@ RUN curl -sL "${OC4_URL}" -o oc.tgz && \
 
 # install: skopeo
 # hadolint ignore=DL3008
-RUN echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers-stable.list && \
-    curl -sL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/Release.key | apt-key add - && \
+RUN apt-get update && \
+    apt-get -y install curl gnupg && \
+    echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/ /' | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
+    curl -fsSL https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/Debian_11/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_stable.gpg >/dev/null && \
+    chown _apt /etc/apt/trusted.gpg.d/*.gpg && \
+    rm -rf /root/.gnupg && \
     apt-get update && \
     apt-get -y --no-install-recommends install skopeo && \
     rm -rf /var/lib/apt/lists/*

--- a/container/base/Dockerfile.codercom
+++ b/container/base/Dockerfile.codercom
@@ -42,6 +42,7 @@ RUN apt-get update && \
     rm -rf /root/.gnupg && \
     apt-get update && \
     apt-get -y --no-install-recommends install skopeo && \
+    apt-get -y upgrade && \
     rm -rf /var/lib/apt/lists/*
 
 # install: entrypoint and other scripts

--- a/container/base/Dockerfile.codercom
+++ b/container/base/Dockerfile.codercom
@@ -1,13 +1,15 @@
 FROM docker.io/codercom/code-server:4.1.0
 
-### https://github.com/opencontainers/image-spec/blob/main/annotations.md
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
 LABEL name="custom-code-server" \
       maintainer="koree@redhat.com" \
       version="4.1.0" \
       summary="Custom Code Server" \
       org.opencontainers.image.description.vendor="codercom" \
       org.opencontainers.image.description="Custom Code Server base image with a basic collection of tools" \
-      org.opencontainers.image.source="https://github.com/codekow/code-server"
+      org.opencontainers.image.source="https://github.com/codekow/code-server" \
+      description="Custom Code Server base image with a basic collection of tools" \
+      io.k8s.description="Custom Code Server base image with a basic collection of tools"
 
 ARG CODE_SERVER_VERSION
 

--- a/container/base/Dockerfile.codercom
+++ b/container/base/Dockerfile.codercom
@@ -18,22 +18,11 @@ ARG CODE_SERVER_VERSION
 USER root
 
 # install: oc
-ENV OC3_VERSION="3.11.374"
-ARG OC3_HASH="1fb49e5548c649d8bab15ac4dca7a77225747b1957c2082f8e47ccbb9120356e"
-ARG OC3_URL="https://mirror.openshift.com/pub/openshift-v3/clients/${OC3_VERSION}/linux/oc.tar.gz"
-
 ENV OC4_VERSION="4.8.10"
 ARG OC4_HASH="9d727adc9438bb7431344a7349ee88fbf05b5dbb856e678013a15c084b72cc9d"
 ARG OC4_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC4_VERSION}/openshift-client-linux.tar.gz"
 
-RUN curl -sL "${OC3_URL}" -o oc.tgz && \
-    sha256sum < oc.tgz && \
-    [ "$OC3_HASH  -" = "$(sha256sum < oc.tgz)" ] && \
-    echo "OC3_HASH: PASSED" && \
-    tar -C /usr/local/bin -zxf oc.tgz oc && \
-    mv /usr/local/bin/oc /usr/local/bin/oc-${OC3_VERSION%.*} && \
-    /usr/local/bin/oc-${OC3_VERSION%.*} completion bash > /etc/bash_completion.d/oc-${OC3_VERSION%.*} && \
-    curl -sL "${OC4_URL}" -o oc.tgz && \
+RUN curl -sL "${OC4_URL}" -o oc.tgz && \
     sha256sum < oc.tgz && \
     [ "$OC4_HASH  -" = "$(sha256sum < oc.tgz)" ] && \
     echo "OC4_HASH: PASSED" && \
@@ -42,6 +31,14 @@ RUN curl -sL "${OC3_URL}" -o oc.tgz && \
     /usr/local/bin/oc-${OC4_VERSION%.*} completion bash > /etc/bash_completion.d/oc-${OC4_VERSION%.*} && \
     rm oc.tgz && \
     ln -s /usr/local/bin/oc-wrapper.sh /usr/local/bin/oc
+
+# install: skopeo
+# hadolint ignore=DL3008
+RUN echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers-stable.list && \
+    curl -sL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/Release.key | apt-key add - && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install skopeo && \
+    rm -rf /var/lib/apt/lists/*
 
 # install: entrypoint and other scripts
 COPY bin /usr/local/bin

--- a/container/base/Dockerfile.ubi8
+++ b/container/base/Dockerfile.ubi8
@@ -26,22 +26,11 @@ RUN useradd coder -u 1000 -g 0 && \
 RUN rpm -ivh https://github.com/cdr/code-server/releases/download/v${CODE_SERVER_VERSION:-4.1.0}/code-server-${CODE_SERVER_VERSION:-4.1.0}-amd64.rpm
 
 # install: oc
-ENV OC3_VERSION="3.11.374"
-ARG OC3_HASH="1fb49e5548c649d8bab15ac4dca7a77225747b1957c2082f8e47ccbb9120356e"
-ARG OC3_URL="https://mirror.openshift.com/pub/openshift-v3/clients/${OC3_VERSION}/linux/oc.tar.gz"
-
 ENV OC4_VERSION="4.8.10"
 ARG OC4_HASH="9d727adc9438bb7431344a7349ee88fbf05b5dbb856e678013a15c084b72cc9d"
 ARG OC4_URL="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OC4_VERSION}/openshift-client-linux.tar.gz"
 
-RUN curl -sL "${OC3_URL}" -o oc.tgz && \
-    sha256sum < oc.tgz && \
-    [ "$OC3_HASH  -" = "$(sha256sum < oc.tgz)" ] && \
-    echo "OC3_HASH: PASSED" && \
-    tar -C /usr/local/bin -zxf oc.tgz oc && \
-    mv /usr/local/bin/oc /usr/local/bin/oc-${OC3_VERSION%.*} && \
-    /usr/local/bin/oc-${OC3_VERSION%.*} completion bash > /etc/bash_completion.d/oc-${OC3_VERSION%.*} && \
-    curl -sL "${OC4_URL}" -o oc.tgz && \
+RUN curl -sL "${OC4_URL}" -o oc.tgz && \
     sha256sum < oc.tgz && \
     [ "$OC4_HASH  -" = "$(sha256sum < oc.tgz)" ] && \
     echo "OC4_HASH: PASSED" && \
@@ -50,6 +39,11 @@ RUN curl -sL "${OC3_URL}" -o oc.tgz && \
     /usr/local/bin/oc-${OC4_VERSION%.*} completion bash > /etc/bash_completion.d/oc-${OC4_VERSION%.*} && \
     rm oc.tgz && \
     ln -s /usr/local/bin/oc-wrapper.sh /usr/local/bin/oc
+
+# install: skopeo
+# hadolint ignore=DL3008
+RUN dnf -y install skopeo fuse-overlayfs && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # install: entrypoint and other scripts
 COPY bin /usr/local/bin

--- a/container/base/Dockerfile.ubi8
+++ b/container/base/Dockerfile.ubi8
@@ -1,13 +1,15 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.5
 
-### https://github.com/opencontainers/image-spec/blob/main/annotations.md
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
 LABEL name="custom-code-server" \
       maintainer="koree@redhat.com" \
       version="4.1.0" \
       summary="Custom Code Server" \
       org.opencontainers.image.description.vendor="codercom" \
       org.opencontainers.image.description="Custom Code Server base image with a basic collection of tools" \
-      org.opencontainers.image.source="https://github.com/codekow/code-server"
+      org.opencontainers.image.source="https://github.com/codekow/code-server" \
+      description="Custom Code Server base image with a basic collection of tools" \
+      io.k8s.description="Custom Code Server base image with a basic collection of tools"
 
 ARG CODE_SERVER_VERSION
 

--- a/container/base/Dockerfile.ubi8
+++ b/container/base/Dockerfile.ubi8
@@ -42,7 +42,7 @@ RUN curl -sL "${OC4_URL}" -o oc.tgz && \
 
 # install: skopeo
 # hadolint ignore=DL3008
-RUN dnf -y install skopeo fuse-overlayfs && \
+RUN dnf -y install skopeo && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # install: entrypoint and other scripts

--- a/container/base/bin/entrypoint.sh
+++ b/container/base/bin/entrypoint.sh
@@ -65,12 +65,13 @@ if [ -f /usr/local/bin/npm-setup.sh ]; then
 fi
 
 # kludge: opinionated defaults
-if [ ! -e ${HOME}/.local/share/code-server/User/settings.json ]; then
-echo "{
-    "workbench.colorTheme": "Abyss",
-    "terminal.integrated.defaultProfile.linux": "bash",
-    "telemetry.enableTelemetry": false
-}" > ${HOME}/.local/share/code-server/User/settings.json
-fi
+#if [ ! -e ${HOME}/.local/share/code-server/User/settings.json ]; then
+#mkdir -p ${HOME}/.local/share/code-server/User
+#echo "{
+#    "workbench.colorTheme": "Abyss",
+#    "terminal.integrated.defaultProfile.linux": "bash",
+#    "telemetry.enableTelemetry": false
+#}" > ${HOME}/.local/share/code-server/User/settings.json
+#fi
 
 exec "$@"

--- a/container/patch/Dockerfile.codercom
+++ b/container/patch/Dockerfile.codercom
@@ -28,14 +28,6 @@ RUN apt-get update && \
 RUN ln -s /usr/bin/python3 /usr/local/bin/python && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip
 
-# install: skopeo
-# hadolint ignore=DL3008
-RUN echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers-stable.list && \
-    curl -sL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Debian_11/Release.key | apt-key add - && \
-    apt-get update && \
-    apt-get -y --no-install-recommends install skopeo && \
-    rm -rf /var/lib/apt/lists/*
-
 # install more tools
 RUN apt-get update && \
     apt-get -y install \

--- a/container/patch/Dockerfile.ubi8
+++ b/container/patch/Dockerfile.ubi8
@@ -24,11 +24,6 @@ RUN dnf -y update && \
 RUN ln -s /usr/bin/python3 /usr/local/bin/python && \
     ln -s /usr/bin/pip3 /usr/local/bin/pip
 
-# install: skopeo
-# hadolint ignore=DL3008
-RUN dnf -y install skopeo fuse-overlayfs && \
-    rm -rf /var/cache /var/log/dnf* /var/log/yum.*
-
 # see https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=true
 # hadolint ignore=DL3008

--- a/openshift/build/build-code-server-base-codercom-template.yml
+++ b/openshift/build/build-code-server-base-codercom-template.yml
@@ -2,14 +2,14 @@
 kind: Template
 apiVersion: template.openshift.io/v1
 labels:
-  template: custom-code-server
+  template: custom-code-server-build-codercom
   app.kubernetes.io/part-of: code-server
   app.kubernetes.io/component: ide
 metadata:
-  name: custom-code-server
+  name: custom-code-server-build-codercom
   annotations:
     openshift.io/display-name: VS Code Server
-    description: Deploy VS Code Server with persistent volume
+    description: Setup a build config for codercom custom code server
     iconClass: icon-python
     tags: python,vscode
     openshift.io/documentation-url: "https://github.com/codekow/ocp-code-server" 
@@ -66,7 +66,7 @@ objects:
   apiVersion: image.openshift.io/v1
   metadata:
     labels:
-      build: ${APPLICATION_NAME}
+      build: ${APPLICATION_NAME}-codercom
     name: ${APPLICATION_NAME}
   spec:
     lookupPolicy:
@@ -89,7 +89,7 @@ objects:
         name: ${DOCKER_IMAGE_TAG}
       - from:
           kind: ImageStreamTag
-          name: ${DOCKER_IMAGE_TAG}
+          name: code-server:${DOCKER_IMAGE_TAG}
         name: "latest"
 - kind: BuildConfig
   apiVersion: build.openshift.io/v1

--- a/openshift/deploy-code-server-no-webdav-template.yml
+++ b/openshift/deploy-code-server-no-webdav-template.yml
@@ -42,7 +42,7 @@ parameters:
   description: Password for Code Server
 - name: CODE_SERVER_IMAGE
   description: The base image for code-server
-  value: openshift/custom-code-server:latest	
+  value: quay.io/codekow/code-server:latest
   required: true
 objects:
 - kind: ImageStream

--- a/openshift/deploy-code-server-no-webdav-template.yml
+++ b/openshift/deploy-code-server-no-webdav-template.yml
@@ -2,14 +2,16 @@
 kind: Template
 apiVersion: template.openshift.io/v1
 labels:
-  template: custom-code-server-no-webdav
+  template: custom-code-server
   app.kubernetes.io/part-of: code-server
   app.kubernetes.io/component: ide
 metadata:
   name: code-server-no-webdav
+  labels:
+    template: custom-code-server
   annotations:
     openshift.io/display-name: VS Code Server (No WebDav)
-    description: TDeploy VS Code Server in OpenShift, no WebDav sidecar
+    description: Deploy VS Code Server in OpenShift, no WebDav sidecar
     iconClass: icon-python
     tags: python,vscode
     openshift.io/documentation-url: "https://github.com/codekow/ocp-code-server" 
@@ -42,7 +44,7 @@ parameters:
   description: Password for Code Server
 - name: CODE_SERVER_IMAGE
   description: The base image for code-server
-  value: quay.io/codekow/code-server:latest
+  value: quay.io/codekow/code-server:ubi8
   required: true
 objects:
 - kind: ImageStream

--- a/openshift/deploy-code-server-template.yml
+++ b/openshift/deploy-code-server-template.yml
@@ -52,11 +52,11 @@ parameters:
   description: Password for Code Server
 - name: CODE_SERVER_IMAGE
   description: The base image for code-server
-  value: openshift/custom-code-server:latest	
+  value: quay.io/codekow/code-server:latest
   required: true
 - name: WEBDAV_NODE_IMAGE
   description: The base image for WebDav
-  value: openshift/webdav-node:latest
+  value: quay.io/codekow/webdav:latest
   required: true
 objects:
 - kind: ImageStream

--- a/openshift/deploy-code-server-template.yml
+++ b/openshift/deploy-code-server-template.yml
@@ -7,6 +7,8 @@ labels:
   app.kubernetes.io/component: ide
 metadata:
   name: code-server
+  labels:
+    template: custom-code-server
   annotations:
     openshift.io/display-name: VS Code Server
     description: Deploy VS Code Server in OpenShift
@@ -52,7 +54,7 @@ parameters:
   description: Password for Code Server
 - name: CODE_SERVER_IMAGE
   description: The base image for code-server
-  value: quay.io/codekow/code-server:latest
+  value: quay.io/codekow/code-server:ubi8
   required: true
 - name: WEBDAV_NODE_IMAGE
   description: The base image for WebDav
@@ -128,7 +130,7 @@ objects:
       dockerStrategy:
         from:
           kind: ImageStreamTag
-          name: '${APPLICATION_NAME}:codercom'
+          name: '${APPLICATION_NAME}:base'
       type: Docker
     successfulBuildsHistoryLimit: 5
     triggers:


### PR DESCRIPTION
Remove old packages to reduce security surface area.

Packages including:
`oc` -  OCP 3.11 is EOL