### PR TITLE
UBI8 on OpenShift fixes

### DIFF
--- a/container/base/Dockerfile.ubi8
+++ b/container/base/Dockerfile.ubi8
@@ -18,9 +18,9 @@ ARG CODE_SERVER_VERSION
 USER root
 
 # setup: coder user
-RUN useradd coder -u 1000 -g 0 && \
-    chmod 700 /home/coder && \
-    chown -R 1000:0 /home/coder
+RUN useradd coder -u 1001 -g 0 && \
+    chgrp -R 0 /home/coder && \
+    chmod -R g=u /home/coder
 
 # install: code-server
 RUN rpm -ivh https://github.com/cdr/code-server/releases/download/v${CODE_SERVER_VERSION:-4.2.0}/code-server-${CODE_SERVER_VERSION:-4.2.0}-amd64.rpm
@@ -42,7 +42,8 @@ RUN curl -sL "${OC4_URL}" -o oc.tgz && \
 
 # install: skopeo
 # hadolint ignore=DL3008
-RUN dnf -y install skopeo && \
+RUN dnf -y install skopeo uid_wrapper nss_wrapper && \
+    dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # install: entrypoint and other scripts

--- a/container/base/Dockerfile.ubi8
+++ b/container/base/Dockerfile.ubi8
@@ -42,7 +42,7 @@ RUN curl -sL "${OC4_URL}" -o oc.tgz && \
 
 # install: skopeo
 # hadolint ignore=DL3008
-RUN dnf -y install skopeo uid_wrapper nss_wrapper && \
+RUN dnf -y install skopeo nss_wrapper && \
     dnf clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 

--- a/container/base/bin/entrypoint.sh
+++ b/container/base/bin/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 if [ -e /usr/lib/x86_64-linux-gnu/libnss_wrapper.so ]; then
     LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
 else
-    LD_PRELOAD=/usr/lib/libnss_wrapper.so
+    LD_PRELOAD=/usr/lib64/libnss_wrapper.so
 fi
 
 NSS_WRAPPER_PASSWD=/tmp/passwd.nss_wrapper
@@ -42,7 +42,6 @@ if [ ! -w /etc/passwd -a x"${USER_ID}" != x"0" -a x"${USER_ID}" != x"1001" ]; th
 
     export NSS_WRAPPER_PASSWD
     export LD_PRELOAD
-
 fi
 
 # fix: node CA trust defaults for requests / node
@@ -65,13 +64,15 @@ if [ -f /usr/local/bin/npm-setup.sh ]; then
 fi
 
 # kludge: opinionated defaults
-#if [ ! -e ${HOME}/.local/share/code-server/User/settings.json ]; then
-#mkdir -p ${HOME}/.local/share/code-server/User
-#echo "{
-#    "workbench.colorTheme": "Abyss",
-#    "terminal.integrated.defaultProfile.linux": "bash",
-#    "telemetry.enableTelemetry": false
-#}" > ${HOME}/.local/share/code-server/User/settings.json
-#fi
+# the below is a requirement for UBI based images (and wont break antything Debian based)
+if [ ! -e ${HOME}/.local/share/code-server/User/settings.json ]; then
+mkdir -p ${HOME}/.local/share/code-server/User
+echo "{
+    "workbench.colorTheme": "Abyss",
+    "terminal.integrated.defaultProfile.linux": "/bin/bash",
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "telemetry.enableTelemetry": false
+}" > ${HOME}/.local/share/code-server/User/settings.json
+fi
 
 exec "$@"

--- a/container/base/bin/entrypoint.sh
+++ b/container/base/bin/entrypoint.sh
@@ -69,7 +69,7 @@ if [ ! -e ${HOME}/.local/share/code-server/User/settings.json ]; then
 mkdir -p ${HOME}/.local/share/code-server/User
 echo "{
     "workbench.colorTheme": "Abyss",
-    "terminal.integrated.defaultProfile.linux": "/bin/bash",
+    "terminal.integrated.defaultProfile.linux": "bash",
     "terminal.integrated.shell.linux": "/bin/bash",
     "telemetry.enableTelemetry": false
 }" > ${HOME}/.local/share/code-server/User/settings.json

--- a/container/base/bin/entrypoint.sh
+++ b/container/base/bin/entrypoint.sh
@@ -64,7 +64,7 @@ if [ -f /usr/local/bin/npm-setup.sh ]; then
 fi
 
 # kludge: opinionated defaults
-# the below is a requirement for UBI based images (and wont break antything Debian based)
+# the below is a requirement for UBI based images (and wont break anything Debian based)
 if [ ! -e ${HOME}/.local/share/code-server/User/settings.json ]; then
 mkdir -p ${HOME}/.local/share/code-server/User
 echo "{

--- a/openshift/build/build-code-server-ubi-template.yml
+++ b/openshift/build/build-code-server-ubi-template.yml
@@ -1,0 +1,159 @@
+---
+kind: Template
+apiVersion: template.openshift.io/v1
+labels:
+  template: custom-code-server-build-ubi
+  app.kubernetes.io/part-of: code-server
+  app.kubernetes.io/component: ide
+metadata:
+  name: custom-code-server-build-ubi
+  annotations:
+    openshift.io/display-name: VS Code Server
+    description: Setup a build config for codercom custom code server
+    iconClass: icon-python
+    tags: python,vscode
+    openshift.io/documentation-url: "https://github.com/codekow/ocp-code-server" 
+    openshift.io/support-url: "https://github.com/codekow/ocp-code-server/issues"
+    template.openshift.io/bindable: "false"
+parameters:
+- name: APPLICATION_NAME
+  displayName: Application Name
+  required: true
+  value: custom-code-server
+- name: BUILD_MEM_LIMIT
+  displayName: Build Memory Limit
+  value: 1Gi
+  required: true
+  description: Consider the pod quota limits
+- name: BUILD_CPU_LIMIT
+  displayName: Build CPU Limit
+  value: 400m
+  required: true
+  description: Consider the pod quota limits
+- name: CUSTOM_PROXY
+  displayName: Proxy server
+  value: ""
+- name: NO_PROXY
+  value: ""
+- name: BUILD_DEPLOY_TOKEN_USERNAME
+  description: "Username to allow cloning of private repos"
+  displayName: "GIT Username"
+- name: BUILD_DEPLOY_TOKEN_PASSWORD
+  description: "Username to allow cloning of private repos"
+  displayName: "GIT Password"
+- name: CONTEXT_DIR
+  description: "Build Source Files Directory"
+  displayName: "Context Directory"
+  value: container/base
+- name: DOCKERFILE
+  description: "Name of the Dockerfile / Containerfile"
+  displayName: "Dockerfile Name"
+  value: Dockerfile.ubi8
+- name: BUILD_REF
+  description: "Branch Name to build from (default: main)"
+  value: main
+- name: BUILD_URL
+  description: "URL to git repo"
+  value: "https://github.com/codekow/ocp-code-server.git"
+- name: DOCKER_IMAGE_BASE
+  description: "Base docker URI for building"
+  value: "registry.access.redhat.com/ubi8/ubi"
+- name: DOCKER_IMAGE_TAG
+  description: "Base docker tag building"
+  value: "latest"
+objects:
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    labels:
+      build: ${APPLICATION_NAME}-ubi
+    name: ${APPLICATION_NAME}
+  spec:
+    lookupPolicy:
+      local: true
+- kind: ImageStream
+  apiVersion: image.openshift.io/v1
+  metadata:
+    annotations:
+      docker.io/source: "${DOCKER_IMAGE_BASE}"
+    labels:
+      build: ${APPLICATION_NAME}
+    name: code-server
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+      - from:
+          kind: DockerImage
+          name: ${DOCKER_IMAGE_BASE}:${DOCKER_IMAGE_TAG}
+        name: ${DOCKER_IMAGE_TAG}
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    labels:
+      build: ${APPLICATION_NAME}
+      app.kubernetes.io/instance: code-server
+    name: ${APPLICATION_NAME}-ubi-base
+    annotations:
+      app.openshift.io/vcs-ref: ${BUILD_REF}
+      app.openshift.io/vcs-uri: ${BUILD_URL}
+  spec:
+    resources:
+      limits:
+        memory: ${BUILD_MEM_LIMIT}
+        cpu: ${BUILD_CPU_LIMIT}
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${APPLICATION_NAME}:ubi-base
+    source:
+      contextDir: ${CONTEXT_DIR}
+      git:
+        uri: ${BUILD_URL}
+        ref: ${BUILD_REF}
+      type: Git
+    strategy:
+      dockerStrategy:
+        dockerfilePath: ${DOCKERFILE}
+        from:
+          kind: ImageStreamTag
+          name: "code-server:${DOCKER_IMAGE_TAG}"
+      type: Docker
+    triggers:
+    - type: ConfigChange
+    - type: ImageChange
+- kind: BuildConfig
+  apiVersion: build.openshift.io/v1
+  metadata:
+    labels:
+      build: custom-code-server
+    name: ${APPLICATION_NAME}-ubi-patch
+  spec:
+    runPolicy: SerialLatestOnly
+    strategy:
+      dockerStrategy:
+        from:
+          kind: ImageStreamTag
+          name: ${APPLICATION_NAME}:ubi-base
+      type: Docker
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${APPLICATION_NAME}:latest
+    triggers:
+      - imageChange:
+        type: ImageChange
+      - type: ConfigChange
+    source:
+      type: dockerfile
+      dockerfile: |
+        FROM scratch
+
+        USER root
+
+        # install your own customizations here
+        # RUN dnf update -y && \
+        #     dnf -y install awesome-tool && \
+        #     dnf clean all
+        
+        USER 1001

--- a/openshift/deploy-code-server-no-webdav-template.yml
+++ b/openshift/deploy-code-server-no-webdav-template.yml
@@ -86,9 +86,9 @@ objects:
         USER root
 
         # install your own customizations here
-        # RUN apt-get update && \
-        #     apt-get -y install --no-install-recommends awesome-tool && \
-        #     rm -rf /var/lib/apt/lists/*
+        # RUN dnf update -y && \
+        #     dnf -y install awesome-tool && \
+        #     dnf clean all
 
         USER 1001
 


### PR DESCRIPTION
New:
- BuildConfig Template for UBI

Updated:
- Dockerfile.ubi8 contains fixes for running UBI on OpenShift
- entrypoint.sh is also included in this to ensure proper NSS Wrapper
  for RHEL based images
- deploy-code-server-no-webdav-template.yml was targeting a UBI image
  but had a "dockerfile" showing apt-get commands

The Dockerfile.ubi8 has been tested on OpenShift 4.6 being built locally
and run via the deploy Template.